### PR TITLE
Forward monster attack events to player machine

### DIFF
--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -71,7 +71,7 @@ export function Game({ fastForwardEvents }: Props) {
           <Grid />
           <Grid>
             {playerActor && <Player actor={playerActor} />}
-            {monsterActor && <Monster actor={monsterActor as any} />}
+            {monsterActor && <Monster actor={monsterActor} />}
           </Grid>
           <Button onClick={() => send("PLAYER_DIED")}>PLAYER DIED</Button>
         </>

--- a/src/components/monster.tsx
+++ b/src/components/monster.tsx
@@ -11,8 +11,8 @@ type MonsterProps = {
 };
 
 export function Monster({ actor }: MonsterProps) {
-  const [state, send] = useActor(actor as any);
-  const { coords } = (state as any).context;
+  const [state, send] = useActor(actor);
+  const { coords } = state.context;
   const position = coordsToPosition(coords);
   return (
     <Layout left={position[0]} top={position[1]}>

--- a/src/machines/game-machine-types.ts
+++ b/src/machines/game-machine-types.ts
@@ -1,6 +1,7 @@
 // Machine Types
 
 import { CoordsType } from "../types";
+import { AttackPlayerType } from "./monster-machine-types";
 
 export interface StartButtonClicked {
   type: "START_BUTTON_CLICKED";
@@ -33,7 +34,8 @@ export type GameEventType =
   | PlayerWalkedThroughDoor
   | RestartButtonClicked
   | HomeButtonClicked
-  | PlayerMovedType;
+  | PlayerMovedType
+  | AttackPlayerType;
 
 export type GameState = {
   context: null;

--- a/src/machines/game-machine.ts
+++ b/src/machines/game-machine.ts
@@ -40,6 +40,9 @@ export const gameMachine = createMachine<null, GameEventType, GameState>(
             entry: `resetPlayerCoords`,
             on: {
               PLAYER_WALKED_THROUGH_DOOR: "level3",
+              ATTACK_PLAYER: {
+                actions: "forwardToPlayer",
+              },
             },
           },
           level3: {
@@ -78,6 +81,7 @@ export const gameMachine = createMachine<null, GameEventType, GameState>(
       ]),
       playerGotTreasure: send("PLAYER_GOT_TREASURE"),
       forwardToMonster: forwardTo("monsterActor"),
+      forwardToPlayer: forwardTo("playerActor"),
     },
     guards: {
       isPlayerAtDoor: (_, event) => {

--- a/src/machines/game-machine.ts
+++ b/src/machines/game-machine.ts
@@ -1,5 +1,5 @@
 import { createMachine } from "xstate";
-import { choose, log, send } from "xstate/lib/actions";
+import { choose, forwardTo, send } from "xstate/lib/actions";
 import { DOOR_COORDS, TREASURE_COORDS } from "../lib/constants";
 import { arrayEquals } from "../lib/util/array-equals";
 import { GameEventType, GameState } from "./game-machine-types";
@@ -77,6 +77,7 @@ export const gameMachine = createMachine<null, GameEventType, GameState>(
         { cond: `isPlayerAtTreasure`, actions: `playerGotTreasure` },
       ]),
       playerGotTreasure: send("PLAYER_GOT_TREASURE"),
+      forwardToMonster: forwardTo("monsterActor"),
     },
     guards: {
       isPlayerAtDoor: (_, event) => {

--- a/src/machines/game-machine.ts
+++ b/src/machines/game-machine.ts
@@ -69,6 +69,7 @@ export const gameMachine = createMachine<null, GameEventType, GameState>(
           cond: `isPlayerAtDoor`,
           actions: `playerWalkedThroughDoor`,
         },
+        { cond: "isMonster", actions: "forwardToMonster" },
       ]),
       playerWalkedThroughDoor: send("PLAYER_WALKED_THROUGH_DOOR"),
       resetPlayerCoords: send("RESET_PLAYER_COORDS", { to: `playerActor` }),

--- a/src/machines/game-machine.ts
+++ b/src/machines/game-machine.ts
@@ -94,6 +94,8 @@ export const gameMachine = createMachine<null, GameEventType, GameState>(
         }
         return false;
       },
+      isMonster: (_, __, conditionMeta) =>
+        !!conditionMeta.state.children.monsterActor,
     },
     services: { playerMachine, monsterMachine },
   }

--- a/src/machines/monster-machine-types.ts
+++ b/src/machines/monster-machine-types.ts
@@ -15,3 +15,7 @@ export type MonsterStateType = {
 export type MonsterEventType = PlayerMovedType;
 
 export type MonsterActorType = ActorRef<MonsterEventType, MonsterStateType>;
+
+export interface AttackPlayerType {
+  type: "ATTACK_PLAYER";
+}

--- a/src/machines/monster-machine-types.ts
+++ b/src/machines/monster-machine-types.ts
@@ -1,5 +1,6 @@
-import { Actor } from "xstate";
+import { Actor, ActorRef } from "xstate";
 import { CoordsType } from "../types";
+import { PlayerMovedType } from "./game-machine-types";
 
 export interface MonsterContextType {
   coords: CoordsType;
@@ -10,4 +11,6 @@ export type MonsterStateType = {
   value: "up" | "down";
 };
 
-export type MonsterActorType = Actor<MonsterContextType>;
+export type MonsterEventType = PlayerMovedType;
+
+export type MonsterActorType = ActorRef<MonsterEventType, MonsterStateType>;

--- a/src/machines/monster-machine-types.ts
+++ b/src/machines/monster-machine-types.ts
@@ -4,6 +4,7 @@ import { PlayerMovedType } from "./game-machine-types";
 
 export interface MonsterContextType {
   coords: CoordsType;
+  playerCoords?: CoordsType;
 }
 
 export type MonsterStateType = {

--- a/src/machines/monster-machine.ts
+++ b/src/machines/monster-machine.ts
@@ -1,7 +1,11 @@
 import { createMachine } from "xstate";
 import { assign } from "xstate/lib/actions";
 import { CoordsType } from "../types";
-import { MonsterContextType, MonsterStateType } from "./monster-machine-types";
+import {
+  MonsterContextType,
+  MonsterEventType,
+  MonsterStateType,
+} from "./monster-machine-types";
 
 const coordsList: CoordsType[] = [
   [8, 1],
@@ -10,7 +14,7 @@ const coordsList: CoordsType[] = [
 
 export const monsterMachine = createMachine<
   MonsterContextType,
-  any,
+  MonsterEventType,
   MonsterStateType
 >(
   {

--- a/src/machines/monster-machine.ts
+++ b/src/machines/monster-machine.ts
@@ -22,10 +22,11 @@ export const monsterMachine = createMachine<
     initial: "up",
     context: {
       coords: coordsList[0],
+      playerCoords: undefined,
     },
     on: {
       PLAYER_MOVED: {
-        actions: log(),
+        actions: "storePlayerCoords",
       },
     },
     states: {
@@ -40,6 +41,9 @@ export const monsterMachine = createMachine<
       }),
       moveDown: assign(() => {
         return { coords: coordsList[1] };
+      }),
+      storePlayerCoords: assign((_, event) => {
+        return { playerCoords: event.coords };
       }),
     },
   }

--- a/src/machines/monster-machine.ts
+++ b/src/machines/monster-machine.ts
@@ -1,5 +1,5 @@
 import { createMachine } from "xstate";
-import { assign } from "xstate/lib/actions";
+import { assign, log } from "xstate/lib/actions";
 import { CoordsType } from "../types";
 import {
   MonsterContextType,
@@ -22,6 +22,11 @@ export const monsterMachine = createMachine<
     initial: "up",
     context: {
       coords: coordsList[0],
+    },
+    on: {
+      PLAYER_MOVED: {
+        actions: log(),
+      },
     },
     states: {
       up: { after: { 2000: { target: "down", actions: "moveDown" } } },

--- a/src/machines/player-machine-types.ts
+++ b/src/machines/player-machine-types.ts
@@ -1,5 +1,6 @@
 import { ActorRef } from "xstate";
 import { CoordsType } from "../types";
+import { AttackPlayerType } from "./monster-machine-types";
 
 export interface PlayerContextType {
   coords: CoordsType;
@@ -24,7 +25,10 @@ export type ArrowButtonClickedType = {
   direction: DirectionType;
 };
 
-export type PlayerEventType = ArrowButtonClickedType | ResetPlayerCoordsType;
+export type PlayerEventType =
+  | ArrowButtonClickedType
+  | ResetPlayerCoordsType
+  | AttackPlayerType;
 
 export type PlayerActorType = ActorRef<any, PlayerStateType>;
 

--- a/src/machines/player-machine.ts
+++ b/src/machines/player-machine.ts
@@ -1,5 +1,5 @@
 import { createMachine } from "xstate";
-import { assign, choose, sendParent } from "xstate/lib/actions";
+import { assign, choose, log, sendParent } from "xstate/lib/actions";
 import {
   PLAYER_STARTING_COORDS,
   PLAYER_STARTING_HEALTH,
@@ -31,6 +31,7 @@ export const playerMachine = createMachine<
         on: {
           ARROW_BUTTON_CLICKED: { actions: "onArrowButtonClicked" },
           RESET_PLAYER_COORDS: { actions: "resetCoords" },
+          ATTACK_PLAYER: { actions: log() },
         },
       },
       dead: {},


### PR DESCRIPTION
This PR adds the ability for the monster to attack the player.

When the two characters overlap an event is sent to the player machine that can be used to reduce player health.